### PR TITLE
Added the compatibility with the renamed target `wasm32-wasip1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## installation
 
 ```bash
-python3 -m pip install rust-contracts-builder
+python -m pip install rust-contracts-builder
 ```
 
 ## init
@@ -19,3 +19,16 @@ cd hello
 rust-contract build --stack-size 8192
 ```
 
+# Development
+
+To run the `tool` from the project folder:
+
+```bash
+python -m pysrc.__main__ build --stack-size 8192
+```
+
+To install the package from the project folder:
+
+```bash
+pip install .
+```


### PR DESCRIPTION
In January 2025 `rustc` started using the name `wasm32-wasip1` as a replacement for `wasm32-wasi`.

The new implementation works like this:
- it uses the **new** `wasm32-wasip1` if available in the list of supported targets
- if not, it tries to use the **legacy** `wasm32-wasi` if available
- if none of them is available, it returns an **error**

For additional information see:
- https://doc.rust-lang.org/nightly/rustc/platform-support/wasm32-wasip1.html
- https://github.com/rust-lang/compiler-team/issues/607
- https://github.com/rust-lang/compiler-team/issues/695
